### PR TITLE
refactor: Streamline iOS Firebase App Distribution workflow

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,25 +12,13 @@ inputs:
   firebase_creds:
     description: 'Firebase credentials'
     required: true
-  github_token:
-    description: 'GitHub token'
-    required: true
-  target_branch:
-    description: 'Target branch for deployment'
+  tester_groups:
+    description: 'Firebase Tester Group'
     required: true
 
 runs:
   using: composite
   steps:
-    - name: Set up Java development environment
-      uses: actions/setup-java@v4.2.2
-      with:
-        distribution: 'zulu'  # Use Zulu distribution of OpenJDK
-        java-version: '17'     # Use Java 17 version
-
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-
     # Cache Gradle dependencies to speed up builds
     - uses: actions/cache@v3
       with:
@@ -54,70 +42,23 @@ runs:
         bundle exec fastlane add_plugin firebase_app_distribution
         bundle exec fastlane add_plugin increment_build_number
 
-    # Generate version number
-    - name: Generate Release Number
-      id: rel_number
-      shell: bash
-      run: |
-        ./gradlew versionFile
-        COMMITS=`git rev-list --count HEAD`
-        TAGS=`git tag | grep -v beta | wc -l`
-        VC=$(((COMMITS+TAGS) << 1))
-        echo "version-code=$VC" >> $GITHUB_OUTPUT
-        VERSION=`cat version.txt`
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-    - name: Generate Release Notes
-      uses: actions/github-script@v7
-      id: release-notes
-      with:
-        github-token: ${{ inputs.github_token }}
-        script: |
-          try {
-            // Get latest release tag
-            const latestRelease = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const previousTag = latestRelease.data.tag_name;
-
-            // Generate release notes
-            const params = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: '${{ steps.rel_number.outputs.version }}',
-              target_commitish: '${{ inputs.target_branch }}'
-            };
-
-            const { data } = await github.rest.repos.generateReleaseNotes(params);
-            const changelog = data.body.replaceAll('`', '\'').replaceAll('"', '\'');
-
-            // Write changelog files
-            const fs = require('fs');
-            fs.writeFileSync('${{ inputs.ios_package_name }}/changelogGithub', changelog);
-
-            // Generate beta changelog
-            const { execSync } = require('child_process');
-            execSync('git log --format="* %s" HEAD^..HEAD > ${{ inputs.ios_package_name }}/changelogBeta');
-
-            return changelog;
-          } catch (error) {
-            console.error('Error generating release notes:', error);
-            return '';
-          }
-
     - name: Inflate Secrets
       shell: bash
       env:
+        GOOGLE_SERVICES: ${{ inputs.google_services }}
         FIREBASE_CREDS: ${{ inputs.firebase_creds }}
       run: |
+        mkdir -p secrets
+        
         # Inflate Firebase credentials
-        touch ${{ inputs.ios_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
-        echo $FIREBASE_CREDS > ${{ inputs.ios_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
+        touch secrets/firebaseAppDistributionServiceCredentialsFile.json
+        echo $FIREBASE_CREDS | base64 --decode > secrets/firebaseAppDistributionServiceCredentialsFile.json
 
-    - name: Build iOS App
+    - name: Upload iOS App to Firebase Distribution
       shell: bash
-      run: bundle exec fastlane ios build_ios
+      run: bundle exec fastlane ios deploy_on_firebase \
+        serviceCredsFile:secrets/firebaseAppDistributionServiceCredentialsFile.json \
+        groups:${{ inputs.tester_groups }}
 
     - name: Upload iOS Artifact
       uses: actions/upload-artifact@v4
@@ -126,7 +67,3 @@ runs:
         retention-days: 1
         compression-level: 9
         path: '**/*.ipa'
-
-    - name: Upload iOS App to Firebase Distribution
-      shell: bash
-      run: bundle exec fastlane ios deploy_on_firebase


### PR DESCRIPTION
This commit simplifies the iOS app deployment workflow to Firebase App Distribution by:

- Removing Java and Gradle setup, relying on Fastlane for building and signing.
- Eliminating automated release notes generation and version management.
- Replacing inline Firebase credentials inflation with a dedicated step.
- Directly deploying the app to Firebase using Fastlane after the build.
- Updating the README with instructions for Fastlane setup and secrets management.
- Focusing on core functionalities: building, signing, and deploying to Firebase.

This streamlining reduces complexity and improves the workflow's efficiency.